### PR TITLE
Remove indent property as its not correct

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -9,11 +9,7 @@
       <property name="indent" value="2"/>
     </properties>
   </rule>
-  <rule ref="PEAR.Classes.ClassDeclaration">
-    <properties>
-      <property name="indent" value="2"/>
-    </properties>
-  </rule>
+  <rule ref="PEAR.Classes.ClassDeclaration"/>
 
   <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
   <rule ref="Generic.Formatting.NoSpaceAfterCast"/>


### PR DESCRIPTION
> Deprecated: Creation of dynamic property PHP_CodeSniffer\Standards\PEAR\Sniffs\Classes\ClassDeclarationSniff::$indent is deprecated in

This only throws an error in older versions of CodeSniffer, but in newer versions this throws a full error and won't execute.